### PR TITLE
Selenium test

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ Instead of 2. it's also possible to run `./setup-tests.sh`
 
 Firefox must be installed to run the test!
 
-Unfortunately an "open context menu and click arrow down on the keyboard" with selenium isn't practical for reaching the context menu entries, therefore, pyautogui is also needed.  
-
 
 ### Publication
 

--- a/README.md
+++ b/README.md
@@ -24,8 +24,25 @@ Work in progress on a browser extension which interacts with the German online d
 3. Run `build.sh`
 
 
-### Publication
+### Test process
 
+1. Install [Python](https://www.python.org/downloads/) (with the systems default package manager; with [asdf](https://asdf-vm.com/guide/getting-started.html); etc.)  
+2. Create virtual environment with `python -m venv venv`    
+2.1 Activate env with `source ./venv/bin/activate`  
+2.2 Install required packages `pip install -r requirements.txt`  
+3. Run `python test.py` to run the End-to-End Test with   
+-> [selenium](https://pypi.org/project/selenium/): for controlling the browser  
+and   
+-> [pyautogui](https://pypi.org/project/PyAutoGUI/): for controlling the mouse
+
+Instead of 2. it's also possible to run `./setup-tests.sh`
+
+Firefox must be installed to run the test!
+
+Unfortunately an "open context menu and click arrow down on the keyboard" with selenium isn't practical for reaching the context menu entries, therefore, pyautogui is also needed.  
+
+
+### Publication
 
 * [Firefox add-on page](https://addons.mozilla.org/firefox/addon/dwds/)
 * [Publish to Webstore](https://developer.chrome.com/docs/webstore/publish/) & [Chrome Webstore search](https://chrome.google.com/webstore/category/extensions)

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ Work in progress on a browser extension which interacts with the German online d
 ### Test process
 
 1. Install [Python](https://www.python.org/downloads/) (with the systems default package manager; with [asdf](https://asdf-vm.com/guide/getting-started.html); etc.)  
+1.1 On Linux base systems also install tk with  
+    `sudo apt install python3-tk python3-dev` or  
+    `sudo pacman -S tk` or  
+    `sudo yum install python3-tk`  
+    depending on your distro..
 2. Create virtual environment with `python -m venv venv`    
 2.1 Activate env with `source ./venv/bin/activate`  
 2.2 Install required packages `pip install -r requirements.txt`  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+selenium
+pyautogui

--- a/setup-tests.sh
+++ b/setup-tests.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -xe
+
+if [ -d "./venv" ]; then
+  echo "venv already exists"
+else
+  echo "creating venv"
+  python3 -m venv venv
+fi
+
+source ./venv/bin/activate
+pip install -r requirements.txt
+
+exit 0

--- a/test.py
+++ b/test.py
@@ -3,20 +3,31 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.common.action_chains import ActionChains
 from pathlib import Path
 import pyautogui
+from platform import system
+
 
 def setup():
     global driver
     global action_chain
     global debugging_url
+    global sys
+
+    sys = system()
 
     debugging_url = "about:debugging#/runtime/this-firefox"
 
     # create firefox instance
     driver = webdriver.Firefox()
+    driver.maximize_window()
     # create actionChain
     action_chain = ActionChains(driver)
     # install project as add-on
     install_temporary_addon(Path.cwd().joinpath('src'))
+
+
+def tear_down():
+    global driver
+    driver.quit()
 
 
 def install_temporary_addon(addon_path):
@@ -25,7 +36,7 @@ def install_temporary_addon(addon_path):
     driver.install_addon(str(addon_path), temporary=True)
 
 
-def decideWhetherToShowDebuggingPageOrNot():
+def decide_whether_to_show_debugging_page_or_not():
     global driver
     global action_chain
     global debugging_url
@@ -39,41 +50,15 @@ def decideWhetherToShowDebuggingPageOrNot():
             driver.get(debugging_url)
             action_chain.pause(5).perform()
 
-def searchWithDwds():
-    global driver
-    global action_chain
-
-    decideWhetherToShowDebuggingPageOrNot()
-
-    x = driver.get_window_position().get('x')
-    y = driver.get_window_position().get('y')
-
-    # move mouse caret to last element in context menu (dwds search) and click the entry
-    pyautogui.moveTo(x + 350, y + 80, duration=1)
-    pyautogui.leftClick()
-
-    pyautogui.write('dwds', interval=0.2)
-    pyautogui.press('space')
-    pyautogui.write('test', interval=0.2)
-
-    action_chain.pause(2).perform()
-
-    pyautogui.press('down')
-    action_chain.pause(0.5).perform()
-    pyautogui.press('enter')
-
-    action_chain.pause(2).perform()
-
 
 # This test navigates to the dwds website, selects text and clicks the context menu entry for redirection to dwds again,
 # but with a search term provided.
-def selectTextAndClickContextMenuEntry():
-    url = "https://www.dwds.de"
-
+def select_text_and_click_context_menu_entry():
     global driver
     global action_chain
+    url = "https://www.dwds.de"
 
-    decideWhetherToShowDebuggingPageOrNot()
+    decide_whether_to_show_debugging_page_or_not()
 
     driver.get(url)
     claim = driver.find_element(By.ID, "navbar").find_element(By.CLASS_NAME, "dwds-claim")
@@ -93,24 +78,53 @@ def selectTextAndClickContextMenuEntry():
     action_chain.pause(1).perform()
 
     # move mouse caret to last element in context menu (dwds search) and click the entry
-    pyautogui.moveTo(x + 450, y + 340, duration=1)
+    sys = system()
+    if sys == 'Windows':
+        pyautogui.moveTo(x + 450, y + 360, duration=1)
+    else:
+        pyautogui.moveTo(x + 450, y + 310, duration=1)
     pyautogui.leftClick()
 
     action_chain.pause(2).perform()
 
-def searchSuggestionsTest():
+
+def focus_address_bar_and_search_with_omnibox_api():
     global driver
+    global action_chain
+
+    decide_whether_to_show_debugging_page_or_not()
+
+    x = driver.get_window_position().get('x')
+    y = driver.get_window_position().get('y')
+
+    # move mouse caret to last element in context menu (dwds search) and click the entry
+    pyautogui.moveTo(x + 350, y + 65, duration=1)
+    pyautogui.leftClick()
+
+    pyautogui.write('dwds', interval=0.2)
+    pyautogui.press('space')
+    pyautogui.write('test', interval=0.2)
+
+    action_chain.pause(2).perform()
+
+    pyautogui.press('down')
+    action_chain.pause(0.5).perform()
+    pyautogui.press('enter')
+
+    action_chain.pause(4).perform()
+
 
 def run_tests():
     # determine working directory
     cwd_path = Path.cwd()
     print("\tCurrent Working Directory (CWD): ", cwd_path)
 
-    # global driver
     setup()
-    selectTextAndClickContextMenuEntry()
-    searchWithDwds()
-    # driver.quit()
+
+    select_text_and_click_context_menu_entry()
+    focus_address_bar_and_search_with_omnibox_api()
+
+    tear_down()
 
 
 run_tests()

--- a/test.py
+++ b/test.py
@@ -39,6 +39,31 @@ def decideWhetherToShowDebuggingPageOrNot():
             driver.get(debugging_url)
             action_chain.pause(5).perform()
 
+def searchWithDwds():
+    global driver
+    global action_chain
+
+    decideWhetherToShowDebuggingPageOrNot()
+
+    x = driver.get_window_position().get('x')
+    y = driver.get_window_position().get('y')
+
+    # move mouse caret to last element in context menu (dwds search) and click the entry
+    pyautogui.moveTo(x + 350, y + 80, duration=1)
+    pyautogui.leftClick()
+
+    pyautogui.write('dwds', interval=0.2)
+    pyautogui.press('space')
+    pyautogui.write('test', interval=0.2)
+
+    action_chain.pause(2).perform()
+
+    pyautogui.press('down')
+    action_chain.pause(0.5).perform()
+    pyautogui.press('enter')
+
+    action_chain.pause(2).perform()
+
 
 # This test navigates to the dwds website, selects text and clicks the context menu entry for redirection to dwds again,
 # but with a search term provided.
@@ -84,6 +109,7 @@ def run_tests():
     # global driver
     setup()
     selectTextAndClickContextMenuEntry()
+    searchWithDwds()
     # driver.quit()
 
 

--- a/test.py
+++ b/test.py
@@ -80,9 +80,9 @@ def select_text_and_click_context_menu_entry():
     # move mouse caret to last element in context menu (dwds search) and click the entry
     sys = system()
     if sys == 'Windows':
-        pyautogui.moveTo(x + 450, y + 360, duration=1)
+        pyautogui.moveTo(x + 450, y + 385, duration=1)
     else:
-        pyautogui.moveTo(x + 450, y + 310, duration=1)
+        pyautogui.moveTo(x + 450, y + 370, duration=1)
     pyautogui.leftClick()
 
     action_chain.pause(2).perform()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,90 @@
+from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+from pathlib import Path
+import pyautogui
+
+def setup():
+    global driver
+    global action_chain
+    global debugging_url
+
+    debugging_url = "about:debugging#/runtime/this-firefox"
+
+    # create firefox instance
+    driver = webdriver.Firefox()
+    # create actionChain
+    action_chain = ActionChains(driver)
+    # install project as add-on
+    install_temporary_addon(Path.cwd().joinpath('src'))
+
+
+def install_temporary_addon(addon_path):
+    global driver
+    # install temporary add-on
+    driver.install_addon(str(addon_path), temporary=True)
+
+
+def decideWhetherToShowDebuggingPageOrNot():
+    global driver
+    global action_chain
+    global debugging_url
+
+    try:
+        with open('skip-about-debugging-page.txt', 'r') as file:
+            skip_debugging_page = file.read()
+    except FileNotFoundError as e:
+        with open('skip-about-debugging-page.txt', 'x') as file:
+            file.write('true')
+            driver.get(debugging_url)
+            action_chain.pause(5).perform()
+
+
+# This test navigates to the dwds website, selects text and clicks the context menu entry for redirection to dwds again,
+# but with a search term provided.
+def selectTextAndClickContextMenuEntry():
+    url = "https://www.dwds.de"
+
+    global driver
+    global action_chain
+
+    decideWhetherToShowDebuggingPageOrNot()
+
+    driver.get(url)
+    claim = driver.find_element(By.ID, "navbar").find_element(By.CLASS_NAME, "dwds-claim")
+
+    x = driver.get_window_position().get('x')
+    y = driver.get_window_position().get('y')
+    print("\tWindow upper left position: ({0}, {1})".format(x, y))
+
+    # select text and open context menu
+    action_chain.move_to_element(claim)\
+        .click_and_hold()\
+        .move_by_offset(10, 0)\
+        .release()\
+        .context_click()\
+        .perform()
+
+    action_chain.pause(1).perform()
+
+    # move mouse caret to last element in context menu (dwds search) and click the entry
+    pyautogui.moveTo(x + 450, y + 340, duration=1)
+    pyautogui.leftClick()
+
+    action_chain.pause(2).perform()
+
+def searchSuggestionsTest():
+    global driver
+
+def run_tests():
+    # determine working directory
+    cwd_path = Path.cwd()
+    print("\tCurrent Working Directory (CWD): ", cwd_path)
+
+    # global driver
+    setup()
+    selectTextAndClickContextMenuEntry()
+    # driver.quit()
+
+
+run_tests()


### PR DESCRIPTION
I was a bit curious about selenium and thought I will create a PR from the result.

This is another PR, based on #4, adding a selenium test to the project. For this to work, python needs to be installed. With the setup script, a python environment is created and the needed modules gets installed (requirements.txt). Afterwards the tests can be run with `python test.py`.

On Ubuntu 22.0.4 with Gnome Desktop Environment the actual flow of opening the browser, navigating to dwds, selecting text and redirect to dwds again, by navigating to - and clicking - the context men item, with the selected text as search term, is working seamlessly.

Unfortunately an "open context menu and click arrow down on the keyboard" with selenium isn't practical for reaching the context menu entries, therefore, pyautogui is also needed.

When problems occur while running this on another OS than Ubuntu, feel free to report.